### PR TITLE
Merge parameter code, close #4

### DIFF
--- a/Treemaker/data/example.cfg
+++ b/Treemaker/data/example.cfg
@@ -6,7 +6,7 @@
 
 [dataset]
 # Required. Cannot be overridden on the command line.
-directory = /eos/uscms/store/user/bjr/ntuples/gstar/Gstar_Hadronic_1500GeV_2WM/
+directory = /eos/uscms/store/user/bjr/ntuples/gstar/Gstar_Semilep_1500GeV_WMLM/
 
 # Optional, defaults to False. Cannot be overridden on the command line
 # (Because overriding a boolean doesn't quite make sense).
@@ -35,5 +35,13 @@ output_file_name =
 # 'plugin with a priority of 1'.
 
 [plugins]
-diffmo_jets = 1
-gstar_preselection = 2
+jhu_ca8_jets = 1
+event_weight = 2
+
+# Section not required.
+# Anything in this section gets loaded into a 'parameters' dictionary that is
+# loaded into the global context of all plugins.
+# The example below is accessible as float(parameters['weight']) from any plugin.
+
+[parameters]
+weight = 42

--- a/Treemaker/python/config.py
+++ b/Treemaker/python/config.py
@@ -15,14 +15,15 @@ defaultTreeName = "tree-" + version
 class TreemakerConfig:
 	
 	def __init__(self, configFileName):
+
+		# Import variables into plugin namespaces
+		self.configVars = {}
+
 		self.configFileName = configFileName
 		if not os.path.exists(configFileName):
 			print "Error: tried to read a config file (" + configFileName + ") that did not exist!"
 			sys.exit(1)
 		self.setup(configFileName)
-
-		# Import variables into plugin namespaces
-		self.configVars = {}
 
 		# Command line options.
 		self.force = False
@@ -72,7 +73,8 @@ class TreemakerConfig:
 		
 		# Parse any config options.
 		try:
-			self.configVars = configParser.items("parameters")
+			for paramName, paramValue in configParser.items("parameters"):
+				self.configVars[paramName] = paramValue
 		except ConfigParser.NoSectionError:
 			pass
 		

--- a/Treemaker/python/config.py
+++ b/Treemaker/python/config.py
@@ -115,7 +115,23 @@ def writeConfigFile(dataset, opts):
 		priority = i + 1
 		plugin = pluginList[i]
 		configParser.set('plugins', plugin, str(priority))
-
+		
+	# Write a params section, if opts.params is not empty.
+	if len(opts.params) > 0:
+		paramDict = {}
+		configParser.add_section('parameters')
+		for param in opts.params:
+			if not '=' in param:
+				print "Error: malformed parameter " + param, " parameters must be of the form x=y."
+				sys.exit(1)
+			name, _, value = param.partition('=')
+			if name in param.keys():
+				print "Error: tried to define parameter " + name + "twice!"
+				sys.exit(1)
+			paramDict[name] = value
+		for name, value in paramDict.iteritems():
+			configParser.set('parameters', name, value)
+		
 	# Write the config parser object to a file.
 	outputName = opts.outputName
 	if outputName == "":

--- a/Treemaker/python/config.py
+++ b/Treemaker/python/config.py
@@ -21,6 +21,9 @@ class TreemakerConfig:
 			sys.exit(1)
 		self.setup(configFileName)
 
+		# Import variables into plugin namespaces
+		self.configVars = {}
+
 		# Command line options.
 		self.force = False
 		self.linear = False
@@ -66,6 +69,12 @@ class TreemakerConfig:
 		self.splitBy = self.parseOption(configParser, 'splitting', 'split_by', -1, 'int')
 		if self.splitBy != -1 and self.splitInto != -1:
 			print "Error: cannot set both split_into and split_by at the same time."
+		
+		# Parse any config options.
+		try:
+			self.configVars = configParser.items("parameters")
+		except ConfigParser.NoSectionError:
+			pass
 		
 		self.readPlugins(configParser)
 	

--- a/Treemaker/python/config.py
+++ b/Treemaker/python/config.py
@@ -117,7 +117,7 @@ def writeConfigFile(dataset, opts):
 		configParser.set('plugins', plugin, str(priority))
 		
 	# Write a params section, if opts.params is not empty.
-	if len(opts.params) > 0:
+	if opts.params is not None and len(opts.params) > 0:
 		paramDict = {}
 		configParser.add_section('parameters')
 		for param in opts.params:
@@ -125,7 +125,7 @@ def writeConfigFile(dataset, opts):
 				print "Error: malformed parameter " + param, " parameters must be of the form x=y."
 				sys.exit(1)
 			name, _, value = param.partition('=')
-			if name in param.keys():
+			if name in paramDict.keys():
 				print "Error: tried to define parameter " + name + "twice!"
 				sys.exit(1)
 			paramDict[name] = value

--- a/Treemaker/python/core.py
+++ b/Treemaker/python/core.py
@@ -26,7 +26,7 @@ from Treemaker.Treemaker import plugins
 # splitting commands. :)
 treemakerTimeout = 43200	# (60 * 60 * 12) seconds
 
-def loadPlugins(config):
+def loadPlugins(config, parameters={}):
 	pluginNames = []
 	try:
 		if config == "":
@@ -44,7 +44,7 @@ def loadPlugins(config):
 		sys.exit(1)
 	
 	# Actually load the plugins.
-	plugins.loadPlugins(pluginNames)
+	plugins.loadPlugins(pluginNames, parameters)
 
 def runOverNtuple(ntuple, outputDir, treename, data=False):
 

--- a/Treemaker/python/core.py
+++ b/Treemaker/python/core.py
@@ -131,7 +131,7 @@ def runTreemaker(treemakerConfig):
 	force = treemakerConfig.force
 	treename = treemakerConfig.treeName
 	index = treemakerConfig.splitIndex
-	plugins.loadPlugins(treemakerConfig.pluginNames)
+	plugins.loadPlugins(treemakerConfig.pluginNames, treemakerConfig.configVars)
 
 	# Create output name
 	print "*** Running treemaker over " + directory

--- a/Treemaker/python/parser.py
+++ b/Treemaker/python/parser.py
@@ -35,6 +35,7 @@ def getCondorParser():
 
 def getConfigParser():
 	parser = getParser()
+	parser.add_option("--param", dest="params", action="append", help="Parameter to write to config file and pass to plugins.")
 	parser.add_option("-p", "--plugin-list", dest="pluginList", help="Newline-separated list of plugins to add to generated config file.", default="")
 	parser.add_option("-o", "--output-name", dest="outputName", help="Name of output file, defaults to name of dataset.", default="")
 	return parser

--- a/Treemaker/python/plugins/__init__.py
+++ b/Treemaker/python/plugins/__init__.py
@@ -30,7 +30,7 @@ def getPossiblePluginNames(namesToLoad=[], location=defaultLocation):
 						names.append(filename)
 	return names
 
-def loadPlugins(pluginNames):
+def loadPlugins(pluginNames, parameters):
 	global plugins
 	
 	# Get a list of all possible plugin names
@@ -47,6 +47,7 @@ def loadPlugins(pluginNames):
 			fp, pathname, description = imp.find_module(name, __path__)
 			try:
 				plugin = imp.load_module(name, fp, pathname, description)
+				plugin.parameters = parameters
 				pluginDict[name] = plugin
 				plugins.append(plugin)
 			finally:

--- a/Treemaker/python/plugins/__init__.py
+++ b/Treemaker/python/plugins/__init__.py
@@ -30,7 +30,7 @@ def getPossiblePluginNames(namesToLoad=[], location=defaultLocation):
 						names.append(filename)
 	return names
 
-def loadPlugins(pluginNames, parameters):
+def loadPlugins(pluginNames, parameters={}):
 	global plugins
 	
 	# Get a list of all possible plugin names

--- a/Treemaker/python/plugins/event_weight.py
+++ b/Treemaker/python/plugins/event_weight.py
@@ -1,0 +1,24 @@
+import array
+
+# Event weights, this is a pretty simple example of the 'parameters' magic.
+
+from Treemaker.Treemaker import cuts
+
+def setup(variables, isData):
+	variables['weight'] = array.array('f', [1.0])
+	return variables
+
+def analyze(event, variables, labels, isData):
+	# load the weight specified in the config file.
+	variables['weight'][0] = float(parameters['weight'])
+	return variables
+
+def reset(variables):
+	variables['weight'][0] = 1.0
+	return variables
+
+def createCuts(cutArray):
+	return cutArray
+
+def makeCuts(event, variables, cutArray, labels, isData):
+	return cutArray

--- a/Treemaker/python/plugins/jhu_ca8_jets.py
+++ b/Treemaker/python/plugins/jhu_ca8_jets.py
@@ -1,0 +1,153 @@
+import array
+import math
+
+import ROOT
+
+# Variant of the jets plugin shipped by Treemaker as an example.
+# Keeps the first three jhuca8 jets.
+# Any per-jet variable goes in here.
+
+# TODO: turn this back into a knob somewhere.
+numJets = 3
+
+class Jet:
+
+	def __init__(self, number, data):
+		self.number = number
+		self.data = data
+
+		self.jetName = "jet" + str(number)
+
+		self.initVars()
+
+	def __matchVectors(self, vectors, vector):
+		"""	A modified version of MatchCol from JetTools.py, written by Marc."""
+		value = -1
+		deltaR = 0.4
+		for i in range(len(vectors)):
+			matching = ROOT.TLorentzVector()
+			matching.SetPtEtaPhiM(vectors[i].Pt(), vectors[i].Eta(), vectors[i].Phi(), vectors[i].M())
+			deltaR = abs(vector.DeltaR(matching))
+			if deltaR < 0.4:
+				value = i
+		if deltaR > 0.4:
+			value = -1
+		return value
+
+	def setup(self, variables):
+		"""	Initializes branch arrays for all jet variables. Returns a copy of the
+		variables dictionary."""
+		variables[self.jetName + 'pt'] = array.array('f', [-1.0])
+		variables[self.jetName + 'mass'] = array.array('f', [-1.0])
+		variables[self.jetName + 'eta'] = array.array('f', [100.0])
+		variables[self.jetName + 'phi'] = array.array('f', [100.0])
+		variables[self.jetName + 'csv'] = array.array('f', [0.0])
+		variables[self.jetName + 'tau21'] = array.array('f', [1.0])
+		variables[self.jetName + 'tau32'] = array.array('f', [1.0])
+		return variables
+
+	def analyze(self, variables, labels):
+		"""	Runs the treemaking step. Labels is a dictionary containing already-
+		loaded handles."""
+		# Do the analysis step.
+		jetCollection = 'PrunedCA8'
+		if not self.data:
+			jetCollection += "CORR"
+		jetHandle = labels['jhuCa8pp'][jetCollection]
+		jetCSVHandle = labels['jhuCa8pp']['PrunedCA8csv']
+		fourVector = jetHandle.product()
+		csvVector = jetCSVHandle.product()
+		try:
+			self.mass = fourVector[self.number - 1].M()
+			self.eta = fourVector[self.number - 1].Eta()
+			self.phi = fourVector[self.number - 1].Phi()
+			self.pt = fourVector[self.number - 1].Pt()
+			self.csv = csvVector[self.number - 1]
+			
+			# Match the jet to the unpruned jet.
+			jetVector = ROOT.TLorentzVector()
+			jetVector.SetPtEtaPhiM(self.pt, self.eta, self.phi, self.mass)
+			unprunedVectors = labels['jhuCa8']['UnprunedCA8'].product()
+			unpruned = self.__matchVectors(unprunedVectors, jetVector)
+			
+			tau1 = labels['jhuCa8']['UnprunedCA8tau1'].product()
+			tau2 = labels['jhuCa8']['UnprunedCA8tau1'].product()
+			tau3 = labels['jhuCa8']['UnprunedCA8tau1'].product()
+			if tau1[unpruned] == 0:
+				self.tau21 = 100
+			elif tau1[unpruned] > 0:
+				self.tau21 = tau2[unpruned] / tau1[unpruned]
+			if tau2[unpruned] == 0:
+				self.tau32 = 100
+			elif tau2[unpruned] > 0:
+				self.tau32 = tau3[unpruned] / tau2[unpruned]
+			
+		except:
+			# If this fails, set all variables to defaults.
+			self.initVars()
+
+		variables = self.update(variables)
+		return variables
+
+	def reset(self, variables):
+		"""	Resets the jet variables and returns an updated copy of the variable
+		array dictionary."""
+		self.initVars()
+		return self.update(variables)
+
+	def update(self, variables):
+		"""	Updates the actual arrays, returns an updated copy of the variable
+		dictionary."""
+		variables[self.jetName + 'mass'][0] = self.mass
+		variables[self.jetName + 'eta'][0] = self.eta
+		variables[self.jetName + 'phi'][0] = self.phi
+		variables[self.jetName + 'pt'][0] = self.pt
+		variables[self.jetName + 'csv'][0] = self.csv
+		variables[self.jetName + 'tau21'][0] = self.tau21
+		variables[self.jetName + 'tau32'][0] = self.tau32
+		return variables
+
+	def initVars(self):
+		"""Initializes the jet variables to default values."""
+		self.mass = -1.0
+		self.pt = -1.0
+		self.eta = 100
+		self.phi = 100
+		self.csv = 0.0
+		self.tau32 = 1.0
+		self.tau21 = 1.0
+
+jets = []
+
+def setup(variables, isData):
+	global jets
+	for i in xrange(numJets):
+		jets.append(Jet(i + 1, isData))
+		variables = jets[i].setup(variables)
+	variables['numjets'] = array.array('f', [0.0])
+	return variables
+
+def createCuts(cutArray):
+	return cutArray
+
+def analyze(event, variables, labels, isData):
+	# Perhaps we should write the number of jets too.
+	for jet in jets:
+		variables = jet.analyze(variables, labels)
+
+	jetCollection = 'PrunedCA8'
+	if not isData:
+		jetCollection += "CORR"
+	jetVectors = labels['jhuCa8pp'][jetCollection].product()
+	variables['numjets'][0] = len(jetVectors)
+
+	return variables
+
+def makeCuts(event, variables, cutArray, labels, isData):
+	return cutArray
+
+def reset(variables):
+	for jet in jets:
+		variables = jet.reset(variables)
+	variables['numjets'][0] = 0.0
+	return variables


### PR DESCRIPTION
This is a totally optional feature that allows the config file to have a section that looks like this:

```
[parameters]
weight = 0.5
```

And then, in a plugin, these parameters can be referenced as follows:

```
weight = float(parameters['weight'])
```

I introduced this so you can avoid hardcoding numbers like, say, the weights of a sample, or the number of jets, into plugins. Hopefully this isn't an example of feature creep- it seemed very useful for the weight of multiple QCD samples that then get added together. (Some old G\* analysis code was written this way).
