### PR TITLE
Include the dbsapi branch, with support for running over xrootd.

### DIFF
--- a/Treemaker/data/condor_template
+++ b/Treemaker/data/condor_template
@@ -7,6 +7,11 @@ request_memory = 199
 Should_Transfer_Files = YES
 WhenToTransferOutput = ON_EXIT
 
+# This might be necessary according to:
+# https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookXrootdService#DownCmd
+# If it isn't, at least add the string for later.
+#use_x509userproxy = true
+
 Transfer_Input_Files=$INPUT_FILES
 Transfer_Output_Files=output_$(Cluster)_$(Process)
 

--- a/Treemaker/data/example.cfg
+++ b/Treemaker/data/example.cfg
@@ -6,7 +6,7 @@
 
 [dataset]
 # Required. Cannot be overridden on the command line.
-directory = /eos/uscms/store/user/bjr/ntuples/gstar/Gstar_Semilep_1500GeV_WMLM/
+directory = /eos/uscms/store/user/bjr/ntuples/gstar/Gstar_Semilep_1500GeV/normal/Gstar_Semilep_1500GeV_WMLM/
 
 # Optional, defaults to False. Cannot be overridden on the command line
 # (Because overriding a boolean doesn't quite make sense).

--- a/Treemaker/data/example_xrd.cfg
+++ b/Treemaker/data/example_xrd.cfg
@@ -1,0 +1,47 @@
+# New improved configuration file style courtesy of v0.3
+# The tool "treemaker-auto -p old_config.cfg dataset" can
+# convert between them.
+
+# I am rethinking allowing the [dataset] params to be overridden.
+
+[dataset]
+# Required. Cannot be overridden on the command line.
+directory = root://cmseos.fnal.gov///eos/uscms/store/user/bjr/ntuples/gstar/Gstar_Semilep_1500GeV/normal/Gstar_Semilep_1500GeV_WMLM/
+
+# Optional, defaults to False. Cannot be overridden on the command line
+# (Because overriding a boolean doesn't quite make sense).
+is_data = False
+
+# Optional, can be overridden by command line arguments.
+output_tree_name =
+output_file_name =
+
+# Optional, mutually exclusive parameters:
+# How many jobs do you want to run at once?
+# VERSUS
+# How many fractional jobs do you want to create?
+# Example: 1000 files. split_into = 300 makes 4 jobs {300, 300, 300, 100}.
+# split_by = 5 makes five jobs {200, 200, 200, 200, 200}.
+
+[splitting]
+#split_into = 300
+#split_by = 5
+
+# Section required, but can be empty.
+# The integer values indicate plugin load order- lower integers get loaded *first*.
+# Integers are priorities; two plugins can have the same priority if you don't
+# care which order things get loaded in.
+# A value of '0' means 'will not run'. A value of '2' means 'will run after any
+# 'plugin with a priority of 1'.
+
+[plugins]
+jhu_ca8_jets = 1
+event_weight = 2
+
+# Section not required.
+# Anything in this section gets loaded into a 'parameters' dictionary that is
+# loaded into the global context of all plugins.
+# The example below is accessible as float(parameters['weight']) from any plugin.
+
+[parameters]
+weight = 42

--- a/Treemaker/python/config.py
+++ b/Treemaker/python/config.py
@@ -55,13 +55,13 @@ class TreemakerConfig:
 		# Parse the directory option.
 		try:
 			self.directory = configParser.get('dataset', 'directory')
-			self.directory = os.path.abspath(os.path.expanduser(self.directory))
 			
-			# For now, if this is a root:// or das:// or dbs://..
-			# we'll just pretend it's okay and catch the problem later.			
-			if not os.path.exists(self.directory) and not ('root://' in self.directory or 'das://' in self.directory or 'dbs://' in self.directory):
-				print "Error: directory '" + directory + "' does not exist!"
-				raise RuntimeError
+			# For now, do no validation here if we're not just a directory.
+			if not ('root://' in self.directory or 'das://' in self.directory or 'dbs://' in self.directory):
+				self.directory = os.path.abspath(os.path.expanduser(self.directory))
+				if not os.path.exists(self.directory):
+					print "Error: directory '" + directory + "' does not exist!"
+					raise RuntimeError
 		except:
 			print "Error: Invalid option for 'directory' in config file."
 		

--- a/Treemaker/python/config.py
+++ b/Treemaker/python/config.py
@@ -6,6 +6,9 @@ import ConfigParser
 import os
 import sys
 
+from Treemaker.Treemaker.dbsapi import constants as DBSConstants
+from Treemaker.Treemaker.dbsapi import util as DBSUtil
+
 # Used so trees from multiple versions do not get hadd'd together.
 version = "0.3"
 
@@ -95,6 +98,19 @@ def writeConfigFile(dataset, opts):
 	configParser.optionxform = str
 
 	configParser.add_section('dataset')
+
+	# Dataset validation, if we are a das://dbs/DATASET form.
+	if "das://" in dataset:
+		try:
+			dbs, name = DBSUtil.parse(dataset)
+			if not dbs in DBSConstants.instances:
+				print "Error: " + dbs + " is not a valid database instance in DAS!"
+				raise RuntimeError
+		except RuntimeError:
+			print "Error: dataset was specified using a DAS URL (das://), but was improperly formatted!"
+			print "Error: formatting should be 'das://instance/dataset'."
+			sys.exit(1)
+
 	configParser.set('dataset', 'directory', dataset)
 	configParser.set('dataset', 'is_data', str(opts.data))
 	configParser.set('dataset', 'output_file_name', opts.name)

--- a/Treemaker/python/config.py
+++ b/Treemaker/python/config.py
@@ -7,7 +7,6 @@ import os
 import sys
 
 from Treemaker.Treemaker.dbsapi import constants as DBSConstants
-from Treemaker.Treemaker.dbsapi import util as DBSUtil
 
 # Used so trees from multiple versions do not get hadd'd together.
 version = "0.3"
@@ -100,9 +99,10 @@ def writeConfigFile(dataset, opts):
 	configParser.add_section('dataset')
 
 	# Dataset validation, if we are a das://dbs/DATASET form.
-	if "das://" in dataset:
+	if "das://" in dataset or 'dbs://' in directory:
 		try:
-			dbs, name = DBSUtil.parse(dataset)
+			_, _, dasName = directory.partition("://")
+			dbs, _, dataset = dasName.partition(":")
 			if not dbs in DBSConstants.instances:
 				print "Error: " + dbs + " is not a valid database instance in DAS!"
 				raise RuntimeError

--- a/Treemaker/python/config.py
+++ b/Treemaker/python/config.py
@@ -56,7 +56,10 @@ class TreemakerConfig:
 		try:
 			self.directory = configParser.get('dataset', 'directory')
 			self.directory = os.path.abspath(os.path.expanduser(self.directory))
-			if not os.path.exists(self.directory):
+			
+			# For now, if this is a root:// or das:// or dbs://..
+			# we'll just pretend it's okay and catch the problem later.			
+			if not os.path.exists(self.directory) and not ('root://' in self.directory or 'das://' in self.directory or 'dbs://' in self.directory):
 				print "Error: directory '" + directory + "' does not exist!"
 				raise RuntimeError
 		except:

--- a/Treemaker/python/core.py
+++ b/Treemaker/python/core.py
@@ -112,7 +112,7 @@ def runTreemaker(treemakerConfig):
 	runner = plugins.PluginRunner(pluginArray)
 
 	# Process "directory"; it may not, after all, be a directory now!
-	ntuples, name = getNtuplesAndName(directory)
+	ntuples, name = filelist.getNtuplesAndName(directory)
 
 	# Create output name
 	if not ".root" in name:

--- a/Treemaker/python/core.py
+++ b/Treemaker/python/core.py
@@ -18,10 +18,9 @@ from DataFormats.FWLite import Events, Handle
 
 # Our own libraries.
 from Treemaker.Treemaker import cuts
+from Treemaker.Treemaker import filelist
 from Treemaker.Treemaker import labels
 from Treemaker.Treemaker import plugins
-
-from Treemaker.Treemaker.dbsapi import dasFileQuery
 
 # Perhaps this should be configurable, but a 'timeout' for the treemaker.
 # If your jobs take longer than 12 hours to run, please make use of the

--- a/Treemaker/python/core.py
+++ b/Treemaker/python/core.py
@@ -111,7 +111,7 @@ def runTreemaker(treemakerConfig):
 	runner = plugins.PluginRunner(pluginArray)
 
 	# Process "directory"; it may not, after all, be a directory now!
-	ntuples, name = filelist.getNtuplesAndName(directory)
+	ntuples, name = filelist.getNtuplesAndName(directory, name)
 
 	# Create output name
 	if not ".root" in name:

--- a/Treemaker/python/dbsapi/constants.py
+++ b/Treemaker/python/dbsapi/constants.py
@@ -1,0 +1,5 @@
+# globals.py
+
+# Logic to get a list of the DBS instances available on DAS.
+# Currently hardcoding. There's probably a better way!
+instances = ['prod/global', 'prod/phys01', 'prod/phys02', 'prod/phys03', 'prod/caf'] 

--- a/Treemaker/python/dbsapi/dasFileQuery.py
+++ b/Treemaker/python/dbsapi/dasFileQuery.py
@@ -3,7 +3,7 @@
 
 import sys
 import json
-import das_client_fork
+import das_client_fork as das_client
 
 def dasFileQuery(dataset):
 	query   = 'dataset dataset=%s' % dataset

--- a/Treemaker/python/dbsapi/dasFileQuery.py
+++ b/Treemaker/python/dbsapi/dasFileQuery.py
@@ -1,0 +1,37 @@
+# A fork of https://github.com/cms-sw/cmssw/blob/CMSSW_7_6_X/HLTrigger/Configuration/python/Tools/dasFileQuery.py,
+# which can query DAS and return a list of files.
+
+import sys
+import json
+import das_client_fork
+
+def dasFileQuery(dataset):
+	query   = 'dataset dataset=%s' % dataset
+	host    = 'https://cmsweb.cern.ch'      # default
+	idx     = 0                             # default
+	limit   = 0                             # unlimited
+	debug   = 0                             # default
+	thr     = 300                           # default
+	ckey    = ""                            # default
+	cert    = ""                            # default
+	jsondict = das_client.get_data(host, query, idx, limit, debug, thr, ckey, cert)
+
+	# check if the pattern matches none, many, or one dataset
+	if not jsondict['data'] or not jsondict['data'][0]['dataset']:
+		sys.stderr.write('Error: the pattern "%s" does not match any dataset\n' % dataset)
+		sys.exit(1)
+		return []
+	elif len(jsondict['data']) > 1:
+		sys.stderr.write('Error: the pattern "%s" matches multiple datasets\n' % dataset)
+		for d in jsondict['data']:
+			sys.stderr.write('    %s\n' % d['dataset'][0]['name'])
+		sys.exit(1)
+		return []
+	else:
+		# expand the dataset name
+		dataset = jsondict['data'][0]['dataset'][0]['name']
+		query = 'file dataset=%s' % dataset
+		jsondict = das_client.get_data(host, query, idx, limit, debug, thr, ckey, cert)
+		# parse the results in JSON format, and extract the list of files
+		files = sorted( f['file'][0]['name'] for f in jsondict['data'] )
+		return files

--- a/Treemaker/python/dbsapi/dasFileQuery.py
+++ b/Treemaker/python/dbsapi/dasFileQuery.py
@@ -5,8 +5,8 @@ import sys
 import json
 import das_client_fork as das_client
 
-def dasFileQuery(dataset):
-	query   = 'dataset dataset=%s' % dataset
+def dasFileQuery(dataset, instance='prod/master'):
+	query   = 'dataset dataset=%s instance=%s' % (dataset, instance)
 	host    = 'https://cmsweb.cern.ch'      # default
 	idx     = 0                             # default
 	limit   = 0                             # unlimited

--- a/Treemaker/python/dbsapi/das_client_fork.py
+++ b/Treemaker/python/dbsapi/das_client_fork.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+#pylint: disable=C0301,C0103,R0914,R0903
+
+# Code imported from here: https://cmsweb.cern.ch/das/cli
+# I am not certain that we can guarantee das_client.py will be available
+# everywhere, so I think if we depend on it it might need to be redistributed...
+# To prevent conflicts I've named this "das_client_fork".
+
+
+"""
+DAS command line tool
+"""
+from __future__ import print_function
+__author__ = "Valentin Kuznetsov"
+
+# system modules
+import os
+import sys
+import pwd
+if  sys.version_info < (2, 6):
+    raise Exception("DAS requires python 2.6 or greater")
+
+DAS_CLIENT = 'das-client/1.1::python/%s.%s' % sys.version_info[:2]
+
+import os
+import re
+import time
+import json
+import urllib
+import urllib2
+import httplib
+import cookielib
+from   optparse import OptionParser
+from   math import log
+from   types import GeneratorType
+
+# define exit codes according to Linux sysexists.h
+EX_OK           = 0  # successful termination
+EX__BASE        = 64 # base value for error messages
+EX_USAGE        = 64 # command line usage error
+EX_DATAERR      = 65 # data format error
+EX_NOINPUT      = 66 # cannot open input
+EX_NOUSER       = 67 # addressee unknown
+EX_NOHOST       = 68 # host name unknown
+EX_UNAVAILABLE  = 69 # service unavailable
+EX_SOFTWARE     = 70 # internal software error
+EX_OSERR        = 71 # system error (e.g., can't fork)
+EX_OSFILE       = 72 # critical OS file missing
+EX_CANTCREAT    = 73 # can't create (user) output file
+EX_IOERR        = 74 # input/output error
+EX_TEMPFAIL     = 75 # temp failure; user is invited to retry
+EX_PROTOCOL     = 76 # remote error in protocol
+EX_NOPERM       = 77 # permission denied
+EX_CONFIG       = 78 # configuration error
+
+class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
+    """
+    Simple HTTPS client authentication class based on provided
+    key/ca information
+    """
+    def __init__(self, key=None, cert=None, level=0):
+        if  level > 1:
+            urllib2.HTTPSHandler.__init__(self, debuglevel=1)
+        else:
+            urllib2.HTTPSHandler.__init__(self)
+        self.key = key
+        self.cert = cert
+
+    def https_open(self, req):
+        """Open request method"""
+        #Rather than pass in a reference to a connection class, we pass in
+        # a reference to a function which, for all intents and purposes,
+        # will behave as a constructor
+        return self.do_open(self.get_connection, req)
+
+    def get_connection(self, host, timeout=300):
+        """Connection method"""
+        if  self.key:
+            return httplib.HTTPSConnection(host, key_file=self.key,
+                                                cert_file=self.cert)
+        return httplib.HTTPSConnection(host)
+
+def x509():
+    "Helper function to get x509 either from env or tmp file"
+    proxy = os.environ.get('X509_USER_PROXY', '')
+    if  not proxy:
+        proxy = '/tmp/x509up_u%s' % pwd.getpwuid( os.getuid() ).pw_uid
+        if  not os.path.isfile(proxy):
+            return ''
+    return proxy
+
+def check_glidein():
+    "Check glideine environment and exit if it is set"
+    glidein = os.environ.get('GLIDEIN_CMSSite', '')
+    if  glidein:
+        msg = "ERROR: das_client is running from GLIDEIN environment, it is prohibited"
+        print(msg)
+        sys.exit(EX__BASE)
+
+def check_auth(key):
+    "Check if user runs das_client with key/cert and warn users to switch"
+    if  not key:
+        msg  = "WARNING: das_client is running without user credentials/X509 proxy, create proxy via 'voms-proxy-init -voms cms -rfc'"
+        print(msg, file=sys.stderr)
+
+class DASOptionParser: 
+    """
+    DAS cache client option parser
+    """
+    def __init__(self):
+        usage  = "Usage: %prog [options]\n"
+        usage += "For more help please visit https://cmsweb.cern.ch/das/faq"
+        self.parser = OptionParser(usage=usage)
+        self.parser.add_option("-v", "--verbose", action="store", 
+                               type="int", default=0, dest="verbose",
+             help="verbose output")
+        self.parser.add_option("--query", action="store", type="string", 
+                               default=False, dest="query",
+             help="specify query for your request")
+        msg  = "host name of DAS cache server, default is https://cmsweb.cern.ch"
+        self.parser.add_option("--host", action="store", type="string", 
+                       default='https://cmsweb.cern.ch', dest="host", help=msg)
+        msg  = "start index for returned result set, aka pagination,"
+        msg += " use w/ limit (default is 0)"
+        self.parser.add_option("--idx", action="store", type="int", 
+                               default=0, dest="idx", help=msg)
+        msg  = "number of returned results (default is 10),"
+        msg += " use --limit=0 to show all results"
+        self.parser.add_option("--limit", action="store", type="int", 
+                               default=10, dest="limit", help=msg)
+        msg  = 'specify return data format (json or plain), default plain.'
+        self.parser.add_option("--format", action="store", type="string",
+                               default="plain", dest="format", help=msg)
+        msg  = 'query waiting threshold in sec, default is 5 minutes'
+        self.parser.add_option("--threshold", action="store", type="int",
+                               default=300, dest="threshold", help=msg)
+        msg  = 'specify private key file name, default $X509_USER_PROXY'
+        self.parser.add_option("--key", action="store", type="string",
+                               default=x509(), dest="ckey", help=msg)
+        msg  = 'specify private certificate file name, default $X509_USER_PROXY'
+        self.parser.add_option("--cert", action="store", type="string",
+                               default=x509(), dest="cert", help=msg)
+        msg  = 'specify number of retries upon busy DAS server message'
+        self.parser.add_option("--retry", action="store", type="string",
+                               default=0, dest="retry", help=msg)
+        msg  = 'show DAS headers in JSON format'
+        msg += ' (obsolete, keep for backward compatibility)'
+        self.parser.add_option("--das-headers", action="store_true",
+                               default=False, dest="das_headers", help=msg)
+        msg = 'specify power base for size_format, default is 10 (can be 2)'
+        self.parser.add_option("--base", action="store", type="int",
+                               default=0, dest="base", help=msg)
+
+        msg = 'a file which contains a cached json dictionary for query -> files mapping'
+        self.parser.add_option("--cache", action="store", type="string",
+                               default=None, dest="cache", help=msg)
+
+        msg = 'List DAS key/attributes, use "all" or specific DAS key value, e.g. site'
+        self.parser.add_option("--list-attributes", action="store", type="string",
+                               default="", dest="keys_attrs", help=msg)
+    def get_opt(self):
+        """
+        Returns parse list of options
+        """
+        return self.parser.parse_args()
+
+def convert_time(val):
+    "Convert given timestamp into human readable format"
+    if  isinstance(val, int) or isinstance(val, float):
+        return time.strftime('%d/%b/%Y_%H:%M:%S_GMT', time.gmtime(val))
+    return val
+
+def size_format(uinput, ibase=0):
+    """
+    Format file size utility, it converts file size into KB, MB, GB, TB, PB units
+    """
+    if  not ibase:
+        return uinput
+    try:
+        num = float(uinput)
+    except Exception as _exc:
+        return uinput
+    if  ibase == 2.: # power of 2
+        base  = 1024.
+        xlist = ['', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
+    else: # default base is 10
+        base  = 1000.
+        xlist = ['', 'KB', 'MB', 'GB', 'TB', 'PB']
+    for xxx in xlist:
+        if  num < base:
+            return "%3.1f%s" % (num, xxx)
+        num /= base
+
+def unique_filter(rows):
+    """
+    Unique filter drop duplicate rows.
+    """
+    old_row = {}
+    row = None
+    for row in rows:
+        row_data = dict(row)
+        try:
+            del row_data['_id']
+            del row_data['das']
+            del row_data['das_id']
+            del row_data['cache_id']
+        except:
+            pass
+        old_data = dict(old_row)
+        try:
+            del old_data['_id']
+            del old_data['das']
+            del old_data['das_id']
+            del old_data['cache_id']
+        except:
+            pass
+        if  row_data == old_data:
+            continue
+        if  old_row:
+            yield old_row
+        old_row = row
+    yield row
+
+def extract_value(row, key):
+    """Generator which extracts row[key] value"""
+    if  isinstance(row, dict) and key in row:
+        if  key == 'creation_time':
+            row = convert_time(row[key])
+        elif  key == 'size':
+            row = size_format(row[key], base)
+        else:
+            row = row[key]
+        yield row
+    if  isinstance(row, list) or isinstance(row, GeneratorType):
+        for item in row:
+            for vvv in extract_value(item, key):
+                yield vvv
+
+def get_value(data, filters, base=10):
+    """Filter data from a row for given list of filters"""
+    for ftr in filters:
+        if  ftr.find('>') != -1 or ftr.find('<') != -1 or ftr.find('=') != -1:
+            continue
+        row = dict(data)
+        values = []
+        keys = ftr.split('.')
+        for key in keys:
+            val = [v for v in extract_value(row, key)]
+            if  key == keys[-1]: # we collect all values at last key
+                values += [json.dumps(i) for i in val]
+            else:
+                row = val
+        if  len(values) == 1:
+            yield values[0]
+        else:
+            yield values
+
+def fullpath(path):
+    "Expand path to full path"
+    if  path and path[0] == '~':
+        path = path.replace('~', '')
+        path = path[1:] if path[0] == '/' else path
+        path = os.path.join(os.environ['HOME'], path)
+    return path
+
+def get_data(host, query, idx, limit, debug, threshold=300, ckey=None,
+        cert=None, das_headers=True):
+    """Contact DAS server and retrieve data for given DAS query"""
+    params  = {'input':query, 'idx':idx, 'limit':limit}
+    path    = '/das/cache'
+    pat     = re.compile('http[s]{0,1}://')
+    if  not pat.match(host):
+        msg = 'Invalid hostname: %s' % host
+        raise Exception(msg)
+    url = host + path
+    client = '%s (%s)' % (DAS_CLIENT, os.environ.get('USER', ''))
+    headers = {"Accept": "application/json", "User-Agent": client}
+    encoded_data = urllib.urlencode(params, doseq=True)
+    url += '?%s' % encoded_data
+    req  = urllib2.Request(url=url, headers=headers)
+    if  ckey and cert:
+        ckey = fullpath(ckey)
+        cert = fullpath(cert)
+        http_hdlr  = HTTPSClientAuthHandler(ckey, cert, debug)
+    else:
+        http_hdlr  = urllib2.HTTPHandler(debuglevel=debug)
+    proxy_handler  = urllib2.ProxyHandler({})
+    cookie_jar     = cookielib.CookieJar()
+    cookie_handler = urllib2.HTTPCookieProcessor(cookie_jar)
+    opener = urllib2.build_opener(http_hdlr, proxy_handler, cookie_handler)
+    fdesc = opener.open(req)
+    data = fdesc.read()
+    fdesc.close()
+
+    pat = re.compile(r'^[a-z0-9]{32}')
+    if  data and isinstance(data, str) and pat.match(data) and len(data) == 32:
+        pid = data
+    else:
+        pid = None
+    iwtime  = 2  # initial waiting time in seconds
+    wtime   = 20 # final waiting time in seconds
+    sleep   = iwtime
+    time0   = time.time()
+    while pid:
+        params.update({'pid':data})
+        encoded_data = urllib.urlencode(params, doseq=True)
+        url  = host + path + '?%s' % encoded_data
+        req  = urllib2.Request(url=url, headers=headers)
+        try:
+            fdesc = opener.open(req)
+            data = fdesc.read()
+            fdesc.close()
+        except urllib2.HTTPError as err:
+            return {"status":"fail", "reason":str(err)}
+        if  data and isinstance(data, str) and pat.match(data) and len(data) == 32:
+            pid = data
+        else:
+            pid = None
+        time.sleep(sleep)
+        if  sleep < wtime:
+            sleep *= 2
+        elif sleep == wtime:
+            sleep = iwtime # start new cycle
+        else:
+            sleep = wtime
+        if  (time.time()-time0) > threshold:
+            reason = "client timeout after %s sec" % int(time.time()-time0)
+            return {"status":"fail", "reason":reason}
+    jsondict = json.loads(data)
+    return jsondict
+
+def prim_value(row):
+    """Extract primary key value from DAS record"""
+    prim_key = row['das']['primary_key']
+    if  prim_key == 'summary':
+        return row[prim_key]
+    key, att = prim_key.split('.')
+    if  isinstance(row[key], list):
+        for item in row[key]:
+            if  att in item:
+                return item[att]
+    else:
+        return row[key][att]
+
+def print_summary(rec):
+    "Print summary record information on stdout"
+    if  'summary' not in rec:
+        msg = 'Summary information is not found in record:\n', rec
+        raise Exception(msg)
+    for row in rec['summary']:
+        keys = [k for k in row.keys()]
+        maxlen = max([len(k) for k in keys])
+        for key, val in row.items():
+            pkey = '%s%s' % (key, ' '*(maxlen-len(key)))
+            print('%s: %s' % (pkey, val))
+        print()
+
+def print_from_cache(cache, query):
+    "print the list of files reading it from cache"
+    data = open(cache).read()
+    jsondict = json.loads(data)
+    if query in jsondict:
+      print("\n".join(jsondict[query]))
+      exit(0)
+    exit(1)
+
+def keys_attrs(lkey, oformat, host, ckey, cert, debug=0):
+    "Contact host for list of key/attributes pairs"
+    url = '%s/das/keys?view=json' % host
+    headers = {"Accept": "application/json", "User-Agent": DAS_CLIENT}
+    req  = urllib2.Request(url=url, headers=headers)
+    if  ckey and cert:
+        ckey = fullpath(ckey)
+        cert = fullpath(cert)
+        http_hdlr  = HTTPSClientAuthHandler(ckey, cert, debug)
+    else:
+        http_hdlr  = urllib2.HTTPHandler(debuglevel=debug)
+    proxy_handler  = urllib2.ProxyHandler({})
+    cookie_jar     = cookielib.CookieJar()
+    cookie_handler = urllib2.HTTPCookieProcessor(cookie_jar)
+    opener = urllib2.build_opener(http_hdlr, proxy_handler, cookie_handler)
+    fdesc = opener.open(req)
+    data = json.load(fdesc)
+    fdesc.close()
+    if  oformat.lower() == 'json':
+        if  lkey == 'all':
+            print(json.dumps(data))
+        else:
+            print(json.dumps({lkey:data[lkey]}))
+        return
+    for key, vdict in data.items():
+        if  lkey == 'all':
+            pass
+        elif lkey != key:
+            continue
+        print()
+        print("DAS key:", key)
+        for attr, examples in vdict.items():
+            prefix = '    '
+            print('%s%s' % (prefix, attr))
+            for item in examples:
+                print('%s%s%s' % (prefix, prefix, item))
+
+def main():
+    """Main function"""
+    optmgr  = DASOptionParser()
+    opts, _ = optmgr.get_opt()
+    host    = opts.host
+    debug   = opts.verbose
+    query   = opts.query
+    idx     = opts.idx
+    limit   = opts.limit
+    thr     = opts.threshold
+    ckey    = opts.ckey
+    cert    = opts.cert
+    base    = opts.base
+    check_glidein()
+    check_auth(ckey)
+    if  opts.keys_attrs:
+        keys_attrs(opts.keys_attrs, opts.format, host, ckey, cert, debug)
+        return
+    if  not query:
+        print('Input query is missing')
+        sys.exit(EX_USAGE)
+    if  opts.format == 'plain':
+        jsondict = get_data(host, query, idx, limit, debug, thr, ckey, cert)
+        cli_msg  = jsondict.get('client_message', None)
+        if  cli_msg:
+            print("DAS CLIENT WARNING: %s" % cli_msg)
+        if  'status' not in jsondict and opts.cache:
+            print_from_cache(opts.cache, query)
+        if  'status' not in jsondict:
+            print('DAS record without status field:\n%s' % jsondict)
+            sys.exit(EX_PROTOCOL)
+        if  jsondict["status"] != 'ok' and opts.cache:
+            print_from_cache(opts.cache, query)
+        if  jsondict['status'] != 'ok':
+            print("status: %s, reason: %s" \
+                % (jsondict.get('status'), jsondict.get('reason', 'N/A')))
+            if  opts.retry:
+                found = False
+                for attempt in xrange(1, int(opts.retry)):
+                    interval = log(attempt)**5
+                    print("Retry in %5.3f sec" % interval)
+                    time.sleep(interval)
+                    data = get_data(host, query, idx, limit, debug, thr, ckey, cert)
+                    jsondict = json.loads(data)
+                    if  jsondict.get('status', 'fail') == 'ok':
+                        found = True
+                        break
+            else:
+                sys.exit(EX_TEMPFAIL)
+            if  not found:
+                sys.exit(EX_TEMPFAIL)
+        nres = jsondict.get('nresults', 0)
+        if  not limit:
+            drange = '%s' % nres
+        else:
+            drange = '%s-%s out of %s' % (idx+1, idx+limit, nres)
+        if  opts.limit:
+            msg  = "\nShowing %s results" % drange
+            msg += ", for more results use --idx/--limit options\n"
+            print(msg)
+        mongo_query = jsondict.get('mongo_query', {})
+        unique  = False
+        fdict   = mongo_query.get('filters', {})
+        filters = fdict.get('grep', [])
+        aggregators = mongo_query.get('aggregators', [])
+        if  'unique' in fdict.keys():
+            unique = True
+        if  filters and not aggregators:
+            data = jsondict['data']
+            if  isinstance(data, dict):
+                rows = [r for r in get_value(data, filters, base)]
+                print(' '.join(rows))
+            elif isinstance(data, list):
+                if  unique:
+                    data = unique_filter(data)
+                for row in data:
+                    rows = [r for r in get_value(row, filters, base)]
+                    print(' '.join(rows))
+            else:
+                print(json.dumps(jsondict))
+        elif aggregators:
+            data = jsondict['data']
+            if  unique:
+                data = unique_filter(data)
+            for row in data:
+                if  row['key'].find('size') != -1 and \
+                    row['function'] == 'sum':
+                    val = size_format(row['result']['value'], base)
+                else:
+                    val = row['result']['value']
+                print('%s(%s)=%s' \
+                % (row['function'], row['key'], val))
+        else:
+            data = jsondict['data']
+            if  isinstance(data, list):
+                old = None
+                val = None
+                for row in data:
+                    prim_key = row.get('das', {}).get('primary_key', None)
+                    if  prim_key == 'summary':
+                        print_summary(row)
+                        return
+                    val = prim_value(row)
+                    if  not opts.limit:
+                        if  val != old:
+                            print(val)
+                            old = val
+                    else:
+                        print(val)
+                if  val != old and not opts.limit:
+                    print(val)
+            elif isinstance(data, dict):
+                print(prim_value(data))
+            else:
+                print(data)
+    else:
+        jsondict = get_data(\
+                host, query, idx, limit, debug, thr, ckey, cert)
+        print(json.dumps(jsondict))
+
+#
+# main
+#
+if __name__ == '__main__':
+    main()

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -39,7 +39,7 @@ def getXRDNtuples(directory):
 			for string in array:
 				searchString = uri + "//" + string
 				if '.root' in string:
-					results.append(string)
+					results.append(searchString)
 				elif string.lstrip().rstrip() == '':
 					continue
 				else:

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -70,7 +70,7 @@ def doSplitting(ntuples, index, splitBy, splitInto):
 	else:
 		return ntuples, numJobs
 
-def getNtuplesAndName(directory):
+def getNtuplesAndName(directory, name=""):
 	if 'dbs://' in directory or 'das://' in directory:
 		# For DAS entries, look them up using dbsapi (or the bit of it we wrote).
 		ntuples, dataset = getDASNtuples(directory)

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -40,8 +40,13 @@ def getXRDNtuples(directory):
 				searchString = uri + "//" + string
 				if '.root' in string:
 					results.append(string)
+				elif string.lstrip().rstrip() == '':
+					continue
 				else:
 					results.extend(getXRDNtuples(searchString))
+			return results
+	except subprocess.CalledProcessError:
+		return []
 	except OSError:
 		print "Error: the xrdfs program is not installed! Cannot proceed!"
 		sys.exit(1)

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -98,11 +98,11 @@ def getNtuplesAndName(directory, name=""):
 	elif 'root://' in directory:
 		print "*** Running treemaker via xrootd over " + directory
 		if name == "":
-			name = directory.rpartition("/")[2]
+			name = directory.rstrip('/').rpartition("/")[2]
 		ntuples = getXRDNtuples(directory)		
 	else:
 		print "*** Running treemaker over " + directory
 		if name == "":
-			name = directory.rpartition("/")[2]
+			name = directory.rstrip('/').rpartition("/")[2]
 		ntuples = getDiskNtuples(directory)
 	return ntuples, name

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -71,7 +71,7 @@ def doSplitting(ntuples, index, splitBy, splitInto):
 		return ntuples, numJobs
 
 def getNtuplesAndName(directory):
-	if 'dbs://' in directory or 'dbs://' in directory:
+	if 'dbs://' in directory or 'das://' in directory:
 		# For DAS entries, look them up using dbsapi (or the bit of it we wrote).
 		ntuples, dataset = getDASNtuples(directory)
 

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -49,6 +49,7 @@ def doSplitting(ntuples, index, splitBy, splitInto):
 	"""	Do job splitting. Given splitting options, a list of files (strings) and an index,
 		splits the files and returns the (index)th set of files to process. Also returns
 		the total number of jobs needed."""
+	numJobs = 1
 	numNtuples = len(ntuples)
 	# These cases should be mutually exclusive.
 	if splitBy > 0:

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -1,0 +1,31 @@
+"""
+Routines to get the list of files to run over.
+"""
+
+import os
+import sys
+
+from Treemaker.Treemaker.dbsapi import dasFileQuery
+from Treemaker.Treemaker.dbsapi import constants
+
+def getDASNtuples(directory):
+	"""	Given a das 'url', extract the list of files to run over.
+		Returns a list of ntuples in xrootd form and the dataset name."""
+	_, _, dasName = directory.partition("://")
+	dbs, _, dataset = dasName.partition(":")
+	if not dbs in constants.instances:
+		print "Error: DBS instance " + dbs + " was not recognized!"
+		sys.exit(1)
+	rawNtuples = dasFileQuery.dasFileQuery(dataset, dbs)
+	ntuples = ["root://cmsxrootd.fnal.gov//" + ntuple for ntuple in rawNtuples]
+	return ntuples, dataset
+
+def getDiskNtuples(directory):
+	"""	Given a directory on a proper filesystem, return a list of ntuples to run over."""
+		# Accumulate a list of files. Subdirectories are okay.
+	ntuples = []
+	for path, dirs, files in os.walk(directory):
+		for ntuple in files:
+			if '.root' in ntuple:
+				ntuples.append(os.path.join(path, ntuple))
+	return ntuples

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -29,3 +29,42 @@ def getDiskNtuples(directory):
 			if '.root' in ntuple:
 				ntuples.append(os.path.join(path, ntuple))
 	return ntuples
+
+def doSplitting(ntuples, index, splitBy, splitInto):
+	"""	Do job splitting. Given splitting options, a list of files (strings) and an index,
+		splits the files and returns the (index)th set of files to process. Also returns
+		the total number of jobs needed."""
+	numNtuples = len(ntuples)
+	# These cases should be mutually exclusive.
+	if splitBy > 0:
+		numJobs = splitBy
+		startJobs = int(math.ceil(numNtuples / float(splitBy))) * index
+		endJobs = int(math.ceil(numNtuples / float(splitBy))) * (index + 1)
+		if index + 1 > splitBy:
+			print "Error: cannot make this splitting with index + 1 > number of splits!"
+			sys.exit(1)
+	elif splitInto > 0:
+		startJobs = splitInto * index
+		endJobs = splitInto * (index + 1)
+		numJobs = int(math.ceil(len(ntuples) / float(splitInto)))
+
+	if (splitBy > 0 or splitInto > 0) and index >= 0:
+		if endJobs > len(ntuples):
+			endJobs = len(ntuples)
+		return ntuples[startJobs:endJobs], numJobs
+	else:
+		return ntuples, numJobs
+
+def getNtuplesAndName(directory):
+	if 'dbs://' in directory or 'dbs://' in directory:
+		# For DAS entries, look them up using dbsapi (or the bit of it we wrote).
+		ntuples, dataset = filelist.getDASNtuples(directory)
+
+		print "*** Running treemaker over dataset " + dataset
+		if name == "":
+			name = dataset.split('/')[1]
+	else:
+		print "*** Running treemaker over " + directory
+		if name == "":
+			name = directory.rpartition("/")[2]
+		ntuples = filelist.getDiskNtuples(directory)

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -73,7 +73,7 @@ def doSplitting(ntuples, index, splitBy, splitInto):
 def getNtuplesAndName(directory):
 	if 'dbs://' in directory or 'dbs://' in directory:
 		# For DAS entries, look them up using dbsapi (or the bit of it we wrote).
-		ntuples, dataset = filelist.getDASNtuples(directory)
+		ntuples, dataset = getDASNtuples(directory)
 
 		print "*** Running treemaker over dataset " + dataset
 		if name == "":
@@ -82,9 +82,9 @@ def getNtuplesAndName(directory):
 		print "*** Running treemaker via xrootd over " + directory
 		if name == "":
 			name = directory.rpartition("/")[2]
-		ntuples = filelist.getXRDNtuples(directory)		
+		ntuples = getXRDNtuples(directory)		
 	else:
 		print "*** Running treemaker over " + directory
 		if name == "":
 			name = directory.rpartition("/")[2]
-		ntuples = filelist.getDiskNtuples(directory)
+		ntuples = getDiskNtuples(directory)

--- a/Treemaker/python/filelist.py
+++ b/Treemaker/python/filelist.py
@@ -88,3 +88,4 @@ def getNtuplesAndName(directory, name=""):
 		if name == "":
 			name = directory.rpartition("/")[2]
 		ntuples = getDiskNtuples(directory)
+	return ntuples, name

--- a/Treemaker/scripts/treemaker-condor
+++ b/Treemaker/scripts/treemaker-condor
@@ -71,8 +71,8 @@ def main():
 		
 		# Process "directory"; it may not, after all, be a directory now!
 		# Then run the splitting routine.
-		ntuples, name = getNtuplesAndName(directory)
-		ntuples, numJobs = doSplitting(ntuples, 0, splitBy, splitInto)
+		ntuples, name = filelist.getNtuplesAndName(directory)
+		ntuples, numJobs = filelist.doSplitting(ntuples, 0, splitBy, splitInto)
 
 		# Now, write out the condor rules for the number of jobs we have.
 		for i in range(numJobs):

--- a/Treemaker/scripts/treemaker-condor
+++ b/Treemaker/scripts/treemaker-condor
@@ -9,6 +9,7 @@ import shutil
 import sys
 
 from Treemaker.Treemaker import config
+from Treemaker.Treemaker import filelist
 from Treemaker.Treemaker import parser
 
 pluginDir = "src/Treemaker/Treemaker/python/plugins"
@@ -67,17 +68,13 @@ def main():
 
 		# Job-splitting support.
 		numJobs = 1
-		if treemakerConfig.splitInto > 0:
-			# dammit, this code is being reused, this should be made better.
-			ntuples = []
-			for path, dirs, files in os.walk(treemakerConfig.directory):
-#				if path == directory:
-				for ntuple in files:
-					if '.root' in ntuple:
-						ntuples.append(os.path.join(path, ntuple))
-			numJobs = int(math.ceil(len(ntuples) / float(treemakerConfig.splitInto)))
-		if treemakerConfig.splitBy > 0:
-			numJobs = treemakerConfig.splitBy
+		
+		# Process "directory"; it may not, after all, be a directory now!
+		# Then run the splitting routine.
+		ntuples, name = getNtuplesAndName(directory)
+		ntuples, numJobs = doSplitting(ntuples, 0, splitBy, splitInto)
+
+		# Now, write out the condor rules for the number of jobs we have.
 		for i in range(numJobs):
 			text += "Arguments = output_$(Cluster)_$(Process)"
 			if numJobs > 1:


### PR DESCRIPTION
The dbsapi branch includes support for running over ntuples located on other remote sites, either by way of a DAS query of a published dataset, or by giving a path in xrootd format.

"Directories" of the form `das://prod/global:/Dataset/Name/USER` will invoke the Treemaker.Treemaker.dbsapi module (which may eventually grow into a something larger but currently just contains a small Python fork of the `das_client.py` script and some helper methods) to look up the files stored in this dataset and run treemaker over all such files, via xrootd.

"Directories" of the form `root://cmseos.fnal.gov///eos/uscms/store/user/...` will just run over all the files stored in this directory,

There are are one or two issues to sort out but it mostly works!
