### PR TITLE
Deprecate the reset function, only call it if plugins have one, resolve #36

### DIFF
--- a/Treemaker/python/core.py
+++ b/Treemaker/python/core.py
@@ -99,8 +99,7 @@ def runOverFile(treemakerConfig, ntuple, outputDir, treename, offset, data=False
 
 		# Set up branches for all variables declared by loaded plugins.
 		# Do this setup in sorted alphabetical order by variable name.
-		variables = {}
-		variables = runner.setupPlugins(variables, data)
+		variables = runner.setupPlugins({}, data)
 		sortedVarNames = sorted(variables)
 		for varName in sortedVarNames:
 			varArray = variables[varName]

--- a/Treemaker/python/plugins/__init__.py
+++ b/Treemaker/python/plugins/__init__.py
@@ -72,6 +72,10 @@ def loadPlugins(pluginNames, parameters={}, silent=False, inputType=""):
 					except AttributeError:
 						pass
 
+					# This is a cleaner way to do the same thing.
+					if inspect.isfunction(plugin.reset):
+						print "Error: deprecated reset function is used in plugin '" + name + "'. Please see https://github.com/TC01/Treemaker/wiki/Deprecations"
+
 				# Complain if a plugin's input type is != what we expect.
 				try:
 					if plugin.input_type != inputType:
@@ -177,8 +181,10 @@ class PluginRunner:
 	def resetPlugins(self, variables):
 
 		# Let plugins call their own reset logic if they really want.
+		# Use inspect to test for the existence of the reset function
 		for plugin in self.plugins:
-			variables = plugin.reset(variables)
+			if inspect.isfunction(plugin.reset):
+				variables = plugin.reset(variables)
 
 		# Now mass reset everything.
 		# Problem: this scribbles over the reset() calls of individual plugins.

--- a/Treemaker/python/plugins/__init__.py
+++ b/Treemaker/python/plugins/__init__.py
@@ -10,8 +10,6 @@ import sys
 
 from Treemaker.Treemaker import constants
 
-plugins = []
-
 ## Helper functions.
 def getScriptLocation():
 	"""Helper function to get the location of a Python file."""
@@ -35,8 +33,8 @@ def getPossiblePluginNames(namesToLoad=[], location=defaultLocation):
 	return names
 
 def loadPlugins(pluginNames, parameters={}, silent=False, inputType=""):
-	global plugins
-	
+	plugins = []
+
 	# Get a list of all possible plugin names
 	names = getPossiblePluginNames(pluginNames.keys())
 	pluginDict = {}
@@ -54,10 +52,17 @@ def loadPlugins(pluginNames, parameters={}, silent=False, inputType=""):
 	# Now, use imp to load all the plugins we specified
 	for name in names:
 		try:
-			test = sys.modules[name]
+
+			# If the plugin was already loaded, behavior depends on the silent flag.
+			# silent = False means this is the first time we're running (so warnings get printed, etc.)
+			# silent = True means it's not, in which case, just append and move on.
+			plugin = sys.modules[name]
 			if not silent:
 				print "*** Error: a module with the name " + name + " was already loaded!"
 				sys.exit(1)
+			else:
+				raise KeyError
+
 		except KeyError:
 			fp, pathname, description = imp.find_module(name, __path__)
 			try:
@@ -74,7 +79,7 @@ def loadPlugins(pluginNames, parameters={}, silent=False, inputType=""):
 
 					# This is a cleaner way to do the same thing.
 					if hasattr(plugin, 'reset'):
-						print "Error: deprecated reset function is used in plugin '" + name + "'. Please see https://github.com/TC01/Treemaker/wiki/Deprecations"
+						print "Warning: deprecated reset function is used in plugin '" + name + "'. Please see https://github.com/TC01/Treemaker/wiki/Deprecations"
 
 				# Complain if a plugin's input type is != what we expect.
 				try:

--- a/Treemaker/python/plugins/__init__.py
+++ b/Treemaker/python/plugins/__init__.py
@@ -73,7 +73,7 @@ def loadPlugins(pluginNames, parameters={}, silent=False, inputType=""):
 						pass
 
 					# This is a cleaner way to do the same thing.
-					if inspect.isfunction(plugin.reset):
+					if hasattr(plugin, 'reset'):
 						print "Error: deprecated reset function is used in plugin '" + name + "'. Please see https://github.com/TC01/Treemaker/wiki/Deprecations"
 
 				# Complain if a plugin's input type is != what we expect.
@@ -183,7 +183,7 @@ class PluginRunner:
 		# Let plugins call their own reset logic if they really want.
 		# Use inspect to test for the existence of the reset function
 		for plugin in self.plugins:
-			if inspect.isfunction(plugin.reset):
+			if hasattr(plugin, 'reset'):
 				variables = plugin.reset(variables)
 
 		# Now mass reset everything.

--- a/Treemaker/python/plugins/event_weight.py
+++ b/Treemaker/python/plugins/event_weight.py
@@ -21,10 +21,6 @@ def analyze(event, variables, labels, isData, cutArray):
 		pass
 	return variables, cutArray
 
-def reset(variables):
-	variables['weight'][0] = 1.0
-	return variables
-
 def createCuts(cutArray):
 	return cutArray
 

--- a/Treemaker/python/plugins/jhu_ca8_jets.py
+++ b/Treemaker/python/plugins/jhu_ca8_jets.py
@@ -145,11 +145,12 @@ def analyze(event, variables, labels, isData, cutArray):
 
 	return variables, cutArray
 
-def reset(variables):
-	for jet in jets:
-		variables = jet.reset(variables)
-	variables['numjets'][0] = 0.0
-	return variables
+# Reset is now done for us!
+#def reset(variables):
+#	for jet in jets:
+#		variables = jet.reset(variables)
+#	variables['numjets'][0] = 0.0
+#	return variables
 
 def drop(event, variables, cutArray, labels, isData):
 	# Only keep events with numjets >= numJets (3).

--- a/Treemaker/python/plugins/jhu_ca8_jets.py
+++ b/Treemaker/python/plugins/jhu_ca8_jets.py
@@ -50,6 +50,7 @@ class Jet:
 	def analyze(self, variables, labels):
 		"""	Runs the treemaking step. Labels is a dictionary containing already-
 		loaded handles."""
+
 		# Do the analysis step.
 		jetCollection = 'PrunedCA8'
 		if not self.data:
@@ -145,12 +146,11 @@ def analyze(event, variables, labels, isData, cutArray):
 
 	return variables, cutArray
 
-# Reset is now done for us!
-#def reset(variables):
-#	for jet in jets:
-#		variables = jet.reset(variables)
-#	variables['numjets'][0] = 0.0
-#	return variables
+# Reset is now done for us but this plugin requires it (sort of).
+def reset(variables):
+	for jet in jets:
+		variables = jet.reset(variables)
+	return variables
 
 def drop(event, variables, cutArray, labels, isData):
 	# Only keep events with numjets >= numJets (3).


### PR DESCRIPTION
As described in #36, reset() is _usually_ (but not always!) a waste of time. Thus, this branch adds functionality for Treemaker to automatically reset your variables for you if you don't call reset(). I've added a deprecation warning for using reset, but if you still need some extra cleanup code the function will still be called in plugins if it's there.

(I should probably provide an option to silence that warning).
